### PR TITLE
uncaptured match

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ assert_eq!(capture_1.values(), &[3, 5, 7]);
 | `[^function_name]` | Match any values that not satisfied given function. |
 | `[^\|x\| *x == 1]` | Match any values that not satisfied given closure. |
 | `.` | Match any values. |
+| `(R)` | numbered capturing group (submatch) |
+| `(?:R)` | non-capturing group |
 | `RS` | `R` followed by `S` |
 | <code>R&#124;S</code> | `R` or `S` (prefer `R`) |
 | `R?` | zero or one `R`, prefer one |

--- a/common/src/regex.rs
+++ b/common/src/regex.rs
@@ -15,6 +15,8 @@ pub enum Regex<T> {
     Concat(Rc<Regex<T>>, Rc<Regex<T>>),
     /// Like a `(R)` in regex. Numbered capturing group (submatch).
     Group(Rc<Regex<T>>),
+    /// Like a `(?:R)` in regex. Numbered non-capturing group.
+    NonCapturingGroup(Rc<Regex<T>>),
     /// Like a `R|S` in regex. Regex alternation.
     Or(Rc<Regex<T>>, Rc<Regex<T>>),
     /// Like a `?`, `??` in regex. Regex zero or one.
@@ -36,6 +38,7 @@ impl<T> std::fmt::Debug for Regex<T> {
             Regex::NotSatisfy(_) => f.debug_tuple("NotSatisfy").field(&"<fn>").finish(),
             Regex::Concat(l, r) => f.debug_tuple("Concat").field(l).field(r).finish(),
             Regex::Group(r) => f.debug_tuple("Group").field(r).finish(),
+            Regex::NonCapturingGroup(r) => f.debug_tuple("NonCaptureGroup").field(r).finish(),
             Regex::Or(l, r) => f.debug_tuple("Or").field(l).field(r).finish(),
             Regex::Repeat0(r, greedy) => f.debug_tuple("Repeat0").field(r).field(greedy).finish(),
             Regex::ZeroOrOne(r, greedy) => {
@@ -61,6 +64,7 @@ impl<T> std::fmt::Display for Regex<T> {
             Regex::NotSatisfy(_) => write!(f, "[^ <fn>]"),
             Regex::Concat(l, r) => write!(f, "{}{}", l, r),
             Regex::Group(r) => write!(f, "({})", r),
+            Regex::NonCapturingGroup(r) => write!(f, "(?:{})", r),
             Regex::Or(l, r) => write!(f, "{}|{}", l, r),
             Regex::Repeat0(r, greedy) => {
                 write!(f, "{}*", r)?;
@@ -161,6 +165,11 @@ impl<T: 'static> Regex<T> {
     /// Like a `(R)` in regex. Numbered capturing group (submatch).
     pub fn group(r: Self) -> Self {
         Regex::Group(r.into())
+    }
+
+    /// Like a `(?:R)` in regex. Numbered capturing group (submatch).
+    pub fn non_capturing_group(r: Self) -> Self {
+        Regex::NonCapturingGroup(r.into())
     }
 
     /// Build regex that matches given value.

--- a/common/src/regex/vm/compiler.rs
+++ b/common/src/regex/vm/compiler.rs
@@ -104,6 +104,14 @@ fn _compile_regex<I>(
             end_pc = r_end_pc + 1;
             new_next_group_index = r_next_group_index;
         }
+        Regex::NonCapturingGroup(r) => {
+            let r_start_pc = start_pc;
+            let (r_insts, r_end_pc, r_next_group_index) =
+                _compile_regex(r, r_start_pc, next_group_index);
+            insts.extend(r_insts);
+            end_pc = r_end_pc;
+            new_next_group_index = r_next_group_index;
+        }
         Regex::Or(r, s) => {
             let r_start_pc = start_pc + 1;
             let (r_insts, r_end_pc, r_next_group_index) =

--- a/common/tests/captures.rs
+++ b/common/tests/captures.rs
@@ -1,7 +1,7 @@
 use vec_reg_common::{CompiledRegex, Regex};
 
 #[test]
-fn no_capture() {
+fn without_capture() {
     let reg = Regex::is(1).compile();
     assert!(reg.captures(&[1]).is_some());
     assert!(reg.captures(&[1]).unwrap().is_empty());
@@ -27,4 +27,22 @@ fn with_capture() {
     let capture_1 = &captures.as_ref().unwrap()[1];
     assert_eq!(capture_1.range, 3..6);
     assert_eq!(capture_1.values(), &[3, 5, 7]);
+}
+
+#[test]
+fn non_capture_group() {
+    let is_even = |x: &i32| x % 2 == 0;
+    let is_odd = |x: &i32| x % 2 == 1;
+    let reg = Regex::concat(
+        Regex::non_capturing_group(Regex::repeat1(Regex::satisfy(is_even), true)),
+        Regex::group(Regex::repeat1(Regex::satisfy(is_odd), true)),
+    )
+    .compile();
+    let captures = reg.captures(&[2, 4, 6, 3, 5, 7]);
+    assert!(captures.is_some());
+    assert_eq!(captures.as_ref().unwrap().len(), 1);
+
+    let capture_0 = &captures.as_ref().unwrap()[0];
+    assert_eq!(capture_0.range, 3..6);
+    assert_eq!(capture_0.values(), &[3, 5, 7]);
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -98,8 +98,18 @@ impl RegexMacroInput {
         } else if input.peek(syn::token::Paren) {
             let parend_content;
             parenthesized!(parend_content in input);
+            let mut capturing = true;
+            if parend_content.parse::<syn::token::Question>().is_ok() && parend_content.parse::<syn::token::Colon>().is_ok() {
+                capturing = false;
+            }
             match Self::parse_expr(&parend_content) {
-                Ok(expr) => Ok(syn::parse_quote!(Regex::group(#expr))),
+                Ok(expr) => {
+                    if capturing {
+                        Ok(syn::parse_quote!(Regex::group(#expr)))
+                    } else {
+                        Ok(syn::parse_quote!(Regex::non_capturing_group(#expr)))
+                    }
+                }
                 Err(error) => Err(error),
             }
         } else {

--- a/macro/tests/try-build-case/group.rs
+++ b/macro/tests/try-build-case/group.rs
@@ -4,4 +4,5 @@ use vec_reg_macro::vec_reg;
 fn main() {
     let is_even = |x: &i32| x % 2 == 0;
     vec_reg!(([is_even]));
+    vec_reg!((?:[is_even]));
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@
 //! | `R{n}` | exactly `n` `R` |
 //! | `R{n}?` | exactly `n` `R` |
 
-pub use vec_reg_common::{CompiledRegex, Regex};
+pub use vec_reg_common::{CompiledRegex, Regex, Capture};
 pub use vec_reg_macro::vec_reg;
 
 #[cfg(doctest)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,6 +21,8 @@
 //! | `[^function_name]` | Match any values that not satisfied given function. |
 //! | <code>[&#94;&#124;x&#124; *x == 1]</code> | Match any values that not satisfied given closure. |
 //! | `.` | Match any values. |
+//! | `(R)` | numbered capturing group (submatch) |
+//! | `(?:R)` | non-capturing group |
 //! | `RS` | `R` followed by `S` |
 //! | <code>R&#124;S</code> | `R` or `S` (prefer `R`) |
 //! | `R?` | zero or one `R`, prefer one |
@@ -36,7 +38,7 @@
 //! | `R{n}` | exactly `n` `R` |
 //! | `R{n}?` | exactly `n` `R` |
 
-pub use vec_reg_common::{CompiledRegex, Regex, Capture};
+pub use vec_reg_common::{Capture, CompiledRegex, Regex};
 pub use vec_reg_macro::vec_reg;
 
 #[cfg(doctest)]

--- a/runtime/tests/captures.rs
+++ b/runtime/tests/captures.rs
@@ -1,73 +1,7 @@
 use vec_reg::{vec_reg, CompiledRegex, Regex};
 
 #[test]
-fn match_without_macro() {
-    let is_fizz = |x: &i32| x % 3 == 0;
-    let is_buzz = |x: &i32| x % 5 == 0;
-    let is_fizz_buzz = |x: &i32| x % 15 == 0;
-    let reg = Regex::concat(
-        Regex::satisfy(is_fizz),
-        Regex::repeat1(
-            Regex::concat(Regex::satisfy(is_buzz), Regex::satisfy(is_fizz_buzz)),
-            true,
-        ),
-    )
-    .compile();
-    assert!(!reg.is_full_match(&[1, 2, 3]));
-    assert!(reg.is_full_match(&[3, 5, 15]));
-    assert!(reg.is_full_match(&[6, 10, 15, 10, 30]));
-}
-
-#[test]
-fn match_with_macro() {
-    let is_fizz = |x: &i32| x % 3 == 0;
-    let is_buzz = |x: &i32| x % 5 == 0;
-    let reg = vec_reg!([is_fizz]([is_buzz][|x| x % 15 == 0])+).compile();
-    assert!(!reg.is_full_match(&[1, 2, 3]));
-    assert!(reg.is_full_match(&[3, 5, 15]));
-    assert!(reg.is_full_match(&[6, 10, 15, 10, 30]));
-}
-
-#[test]
-fn match_repeat_n_macro() {
-    let is_even = |x: &i32| x % 2 == 0;
-    let is_odd = |x: &i32| x % 2 == 1;
-
-    let reg1 = vec_reg!([is_even]{2}).compile();
-    let reg2 = vec_reg!([is_even]{2,}).compile();
-    let reg3 = vec_reg!([is_even]{2,3}).compile();
-    let reg4 = vec_reg!(([is_even]|[is_odd]){2,3}).compile();
-
-    assert!(!reg1.is_full_match(&[2]));
-    assert!(reg1.is_full_match(&[2, 4]));
-    assert!(!reg1.is_full_match(&[2, 4, 6]));
-
-    assert!(!reg2.is_full_match(&[2]));
-    assert!(reg2.is_full_match(&[2, 4]));
-    assert!(reg2.is_full_match(&[2, 4, 6]));
-
-    assert!(!reg3.is_full_match(&[2]));
-    assert!(reg3.is_full_match(&[2, 4]));
-    assert!(reg3.is_full_match(&[2, 4, 6]));
-    assert!(!reg3.is_full_match(&[2, 4, 6, 8]));
-
-    assert!(!reg4.is_full_match(&[2]));
-    assert!(reg4.is_full_match(&[1, 2]));
-    assert!(reg4.is_full_match(&[1, 2, 3]));
-    assert!(!reg4.is_full_match(&[1, 2, 3, 4]));
-}
-
-#[test]
-fn match_inverse_macro() {
-    let is_even = |x: &i32| x % 2 == 0;
-    let reg1 = vec_reg!([^is_even]).compile();
-    let reg2 = vec_reg!([^|x| x % 2 == 0]).compile();
-    assert!(reg1.is_full_match(&[1]));
-    assert!(reg2.is_full_match(&[1]));
-}
-
-#[test]
-fn test_submatches() {
+fn capturing_group() {
     let is_even = |x: &i32| x % 2 == 0;
     let is_odd = |x: &i32| x % 2 == 1;
     let reg = vec_reg!(([is_even]+)([is_odd]+)).compile();
@@ -82,4 +16,18 @@ fn test_submatches() {
     let capture_1 = &captures.as_ref().unwrap()[1];
     assert_eq!(capture_1.range, 3..6);
     assert_eq!(capture_1.values(), &[3, 5, 7]);
+}
+
+#[test]
+fn non_capturing_group() {
+    let is_even = |x: &i32| x % 2 == 0;
+    let is_odd = |x: &i32| x % 2 == 1;
+    let reg = vec_reg!((?:[is_even]+)([is_odd]+)).compile();
+    let captures = reg.captures(&[2, 4, 6, 3, 5, 7]);
+    assert!(captures.is_some());
+    assert_eq!(captures.as_ref().unwrap().len(), 1);
+
+    let capture_0 = &captures.as_ref().unwrap()[0];
+    assert_eq!(capture_0.range, 3..6);
+    assert_eq!(capture_0.values(), &[3, 5, 7]);
 }


### PR DESCRIPTION
Add support `(?:R)` non-capturing group.

- feature: Add non-capturing group Regex enum.
- feature: Add support non-capturing macro syntax.
